### PR TITLE
Update build.rs: liblmdb -> lmdb

### DIFF
--- a/lmdb-sys/build.rs
+++ b/lmdb-sys/build.rs
@@ -59,7 +59,7 @@ fn main() {
         warn!("Building with `-fsanitize=fuzzer`.");
     }
 
-    if !pkg_config::find_library("liblmdb").is_ok() {
+    if !pkg_config::find_library("lmdb").is_ok() {
         let mut builder = cc::Build::new();
 
         builder


### PR DESCRIPTION
On my machine (Gentoo 23.0) and [Ubuntu 24.04](https://packages.ubuntu.com/search?searchon=contents&keywords=lmdb.pc&mode=exactfilename&suite=noble&arch=amd64), the library is installed as `lmdb` and not `liblmdb`.